### PR TITLE
Set AGG backend by default

### DIFF
--- a/pychemy/__init__.py
+++ b/pychemy/__init__.py
@@ -1,1 +1,3 @@
+import matplotlib as mpl
 __version__ = '0.4.4'
+mpl.use('AGG')


### PR DESCRIPTION
Pychemy should never use a matplotlib backend that requires a GUI.